### PR TITLE
Update jenkins-setup.sh to reflect latest jenkins package

### DIFF
--- a/userdata/jenkins-setup.sh
+++ b/userdata/jenkins-setup.sh
@@ -2,7 +2,7 @@
 sudo apt update
 sudo apt install openjdk-11-jdk -y
 sudo apt install maven -y
-curl -fsSL https://pkg.jenkins.io/debian-stable/jenkins.io.key | sudo tee \
+curl -fsSL https://pkg.jenkins.io/debian-stable/jenkins.io-2023.key | sudo tee \
   /usr/share/keyrings/jenkins-keyring.asc > /dev/null
 echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] \
   https://pkg.jenkins.io/debian-stable binary/ | sudo tee \


### PR DESCRIPTION
As per the official post from jenkins team, "Administrators of Linux systems must install the new signing keys on their Linux servers before installing Jenkins Jenkins weekly 2.397 or Jenkins LTS 2.387.2." So updated the jenkins.sh accordingly