### PR TITLE
correct java8 version install package as per amazon linux

### DIFF
--- a/userdata/nexus-setup.sh
+++ b/userdata/nexus-setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-yum install java-1.8.0-openjdk.x86_64 wget -y   
+yum install java-1.8.0-amazon-corretto.x86_64
 mkdir -p /opt/nexus/   
 mkdir -p /tmp/nexus/                           
 cd /tmp/nexus/


### PR DESCRIPTION
Hi Imran , 

I think this is the correct version of the Java8 that has to be installed on the amazon linux machine which can provision the nexus ,
checked it locally by myself after changing the version 