### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
  		    <plugin>
  		        <groupId>org.jacoco</groupId>
  		        <artifactId>jacoco-maven-plugin</artifactId>
-			<version>0.8.4</version>
+			<version>0.8.7</version>
  		        <executions>
  		            <execution>
  		                <id>jacoco-initialize</id>


### PR DESCRIPTION
jacoco file updated 0.8.4 to 0.8.7 becasue my Jenkins pipeline java version tool is 17, otherwise java 11 will accept jacoco 0.8.4 but reject my version of the Java Runtime (class file version 61.0) which only accepts java verison 17.